### PR TITLE
Bug/git-errorhandling

### DIFF
--- a/statusline/git.py
+++ b/statusline/git.py
@@ -27,10 +27,12 @@ class Git(object):
         except CalledProcessError as e:
             return None
 
-    def _count(self, command: list) -> int:
-        results = self._run_command(command).split("\n")
-        results.remove("")
-        return len(results)
+    def _count(self, command: list) -> Optional[int]:
+        results = self._run_command(command)
+        if results:
+            results = results.split("\n")
+            results.remove("")
+            return len(results)
 
     @property
     def root_dir(self) -> Optional[str]:

--- a/statusline/git.py
+++ b/statusline/git.py
@@ -87,7 +87,7 @@ class Git(object):
         return Status(**result)
 
     def stashes(self) -> int:
-        return self._count(["stash", "list", "--porcelain"])
+        return self._count(["stash", "list"])
 
     def short_stats(self) -> str:
         # branch logo in git color #f14e32 (colour 202 is ideal)

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -21,6 +21,7 @@ class Test_Git(unittest.TestCase):
     def test__count(self):
         tests = [
             (["stash", "list"], "stash@{0}\nstash@{1}\n", 2),
+            (["stash", "list", "--porcelain"], None, None),
         ]
         for cmd, mock, expected in tests:
             with patch("statusline.git.Git._run_command", return_value=mock) as mock:

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -20,7 +20,7 @@ class Test_Git(unittest.TestCase):
 
     def test__count(self):
         tests = [
-            (["stash", "list", "--porcelain"], "stash@{0}\nstash@{1}\n", 2),
+            (["stash", "list"], "stash@{0}\nstash@{1}\n", 2),
         ]
         for cmd, mock, expected in tests:
             with patch("statusline.git.Git._run_command", return_value=mock) as mock:
@@ -92,7 +92,7 @@ class Test_Git(unittest.TestCase):
     @patch("statusline.git.Git._count", return_value=1)
     def test_stashes(self, mock):
         self.assertEqual(1, self.instance.stashes())
-        mock.assert_called_once_with(["stash", "list", "--porcelain"])
+        mock.assert_called_once_with(["stash", "list"])
 
     # TODO should we mock more of the ansi calls here?
     @patch("statusline.git.rgb.rgb256", return_value="")


### PR DESCRIPTION
dealt with errorcases from `git stash list --porcelain` being unsupported and from _run_command optionally returning None