### PR TITLE
encapsulate ansi escapes

### DIFF
--- a/statusline/ansi_patch.py
+++ b/statusline/ansi_patch.py
@@ -1,0 +1,13 @@
+from ansi.colour.base import Graphic
+from ansi.sequence import sequence
+
+
+def patch(self):
+    return '\001%s\002' % self.sequence
+
+
+Graphic.__str__ = patch
+
+
+def colour256(colour):
+    return '\001%s\002' % sequence('m', fields=3)(38, 5, colour)

--- a/statusline/git.py
+++ b/statusline/git.py
@@ -103,10 +103,10 @@ class Git:
         Colour coding is done with terminal escapes.
         """
         # branch logo in git color #f14e32 (colour 202 is ideal)
-        result = [rgb.rgb256(241, 78, 50), '\uE0A0', fx.reset, self.branch]
+        result = ['\001', rgb.rgb256(241, 78, 50), '\002\uE0A0\001', fx.reset, '\002', self.branch]
         ahead_behind = self.ahead_behind()
         if ahead_behind.ahead and ahead_behind.behind:
-            result.extend([fg.black+bg.brightred, '↕%d' % sum(ahead_behind), fx.reset])
+            result.extend(['\001', fg.black+bg.brightred, '\002↕%d' % sum(ahead_behind), '\001', fx.reset, '\002'])
         elif ahead_behind.ahead:
             result.append('↑%d' % ahead_behind.ahead)
         elif ahead_behind.behind:
@@ -115,12 +115,12 @@ class Git:
         if sum(status):
             result.append('(')
             if status.staged:
-                result.extend([fg.green, status.staged])
+                result.extend(['\001', fg.green, '\002', status.staged])
             if status.unstaged:
-                result.extend([fg.red, status.unstaged])
+                result.extend(['\001', fg.red, '\002', status.unstaged])
             if status.untracked:
-                result.extend([fg.brightblack, status.untracked])
-            result.extend([fx.reset, ')'])
+                result.extend(['\001', fg.brightblack, '\002', status.untracked])
+            result.extend(['\001', fx.reset, '\002)'])
         stashes = self.stashes()
         if stashes:
             result.append('{%d}' % stashes)

--- a/statusline/git.py
+++ b/statusline/git.py
@@ -3,6 +3,7 @@ from os import path
 from subprocess import run
 from collections import namedtuple, defaultdict
 
+from statusline import ansi_patch
 from ansi.colour import fg, bg, fx, rgb
 
 AheadBehind = namedtuple('AheadBehind', ('ahead', 'behind'), defaults=(0, 0))
@@ -103,10 +104,11 @@ class Git:
         Colour coding is done with terminal escapes.
         """
         # branch logo in git color #f14e32 (colour 202 is ideal)
-        result = ['\001', rgb.rgb256(241, 78, 50), '\002\uE0A0\001', fx.reset, '\002', self.branch]
+        # rgb.rgb256(241, 78, 50)
+        result = [ansi_patch.colour256(202), '\uE0A0', fx.reset, self.branch]
         ahead_behind = self.ahead_behind()
         if ahead_behind.ahead and ahead_behind.behind:
-            result.extend(['\001', fg.black+bg.brightred, '\002↕%d' % sum(ahead_behind), '\001', fx.reset, '\002'])
+            result.extend([fg.black+bg.brightred, '↕%d' % sum(ahead_behind), fx.reset])
         elif ahead_behind.ahead:
             result.append('↑%d' % ahead_behind.ahead)
         elif ahead_behind.behind:
@@ -115,12 +117,12 @@ class Git:
         if sum(status):
             result.append('(')
             if status.staged:
-                result.extend(['\001', fg.green, '\002', status.staged])
+                result.extend([fg.green, status.staged])
             if status.unstaged:
-                result.extend(['\001', fg.red, '\002', status.unstaged])
+                result.extend([fg.red, status.unstaged])
             if status.untracked:
-                result.extend(['\001', fg.brightblack, '\002', status.untracked])
-            result.extend(['\001', fx.reset, '\002)'])
+                result.extend([fg.brightblack, status.untracked])
+            result.extend([fx.reset, ')'])
         stashes = self.stashes()
         if stashes:
             result.append('{%d}' % stashes)

--- a/statusline/status.py
+++ b/statusline/status.py
@@ -17,7 +17,7 @@ class DirectoryMinify:
         return name
 
     def hi(self, text):
-        return fg.brightblue(text)
+        return '\001%s\002' % fg.brightblue(text)
 
     def minify_path(self, path: str, home=os.path.expanduser('~'), keep = 1):
         """Minify a path string.

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -112,32 +112,30 @@ def test_stashes(mock, instance):
 
 
 @pytest.mark.parametrize('branch, ab, status, stashes, expected', (
-    ('master', AheadBehind(0, 0), Status(0, 0, 0), 0, '\001\002\uE0A0\001\033[0m\002master'),
+    ('master', AheadBehind(0, 0), Status(0, 0, 0), 0, '\001\033[38;5;202m\002\uE0A0\001\033[0m\002master'),
     (
         'master',
         AheadBehind(1, 0),
         Status(3, 2, 0),
         0,
-        '\001\002\uE0A0\001\033[0m\002master↑1(\001\033[32m\0023\001\033[31m\0022\001\033[0m\002)',
+        '\001\033[38;5;202m\002\uE0A0\001\033[0m\002master↑1(\001\033[32m\0023\001\033[31m\0022\001\033[0m\002)',
     ),
     (
         'master',
         AheadBehind(0, 1),
         Status(0, 0, 5),
         0,
-        '\001\002\uE0A0\001\033[0m\002master↓1(\001\033[90m\0025\001\033[0m\002)',
+        '\001\033[38;5;202m\002\uE0A0\001\033[0m\002master↓1(\001\033[90m\0025\001\033[0m\002)',
     ),
     (
         'master',
         AheadBehind(3, 2),
         Status(0, 0, 0),
         1,
-        '\001\002\uE0A0\001\033[0m\002master\001\033[30;101m\002↕5\001\033[0m\002{1}',
+        '\001\033[38;5;202m\002\uE0A0\001\033[0m\002master\001\033[30;101m\002↕5\001\033[0m\002{1}',
     ),
 ))
-# TODO should we mock more of the ansi calls here?
-@patch('statusline.git.rgb.rgb256', return_value='')
-def test_short_stats(mock, branch, ab, status, stashes, expected, instance):
+def test_short_stats(branch, ab, status, stashes, expected, instance):
     with patch(
         'statusline.git.Git.branch', new_callable=PropertyMock, return_value=branch
     ), patch(

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -112,27 +112,27 @@ def test_stashes(mock, instance):
 
 
 @pytest.mark.parametrize('branch, ab, status, stashes, expected', (
-    ('master', AheadBehind(0, 0), Status(0, 0, 0), 0, '\uE0A0\033[0mmaster'),
+    ('master', AheadBehind(0, 0), Status(0, 0, 0), 0, '\001\002\uE0A0\001\033[0m\002master'),
     (
         'master',
         AheadBehind(1, 0),
         Status(3, 2, 0),
         0,
-        '\uE0A0\033[0mmaster↑1(\033[32m3\033[31m2\033[0m)',
+        '\001\002\uE0A0\001\033[0m\002master↑1(\001\033[32m\0023\001\033[31m\0022\001\033[0m\002)',
     ),
     (
         'master',
         AheadBehind(0, 1),
         Status(0, 0, 5),
         0,
-        '\uE0A0\033[0mmaster↓1(\033[90m5\033[0m)',
+        '\001\002\uE0A0\001\033[0m\002master↓1(\001\033[90m\0025\001\033[0m\002)',
     ),
     (
         'master',
         AheadBehind(3, 2),
         Status(0, 0, 0),
         1,
-        '\uE0A0\033[0mmaster\033[30;101m↕5\033[0m{1}',
+        '\001\002\uE0A0\001\033[0m\002master\001\033[30;101m\002↕5\001\033[0m\002{1}',
     ),
 ))
 # TODO should we mock more of the ansi calls here?


### PR DESCRIPTION
Wrap ansi escape codes in \001 and \002 so they don't mess with the length of the prompt they appear in.

Doing this in the code base is horrendously ugly, it would be better to monkey patch the ansi module if possible.