### PR TITLE
handle errors without upstream

### DIFF
--- a/statusline/git.py
+++ b/statusline/git.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 from os import path
-from subprocess import run
+from subprocess import run, CalledProcessError
 from collections import namedtuple, defaultdict
 
 from ansi.colour import fg, bg, fx, rgb
@@ -75,8 +75,12 @@ class Git:
 
     def ahead_behind(self) -> AheadBehind:
         """Count unsynched commits between current branch and it's remote."""
-        ahead = self._count(['rev-list', '@{u}..HEAD'])
-        behind = self._count(['rev-list', 'HEAD..@{u}'])
+        try:
+            ahead = self._count(['rev-list', '@{u}..HEAD'])
+            behind = self._count(['rev-list', 'HEAD..@{u}'])
+        except CalledProcessError:
+            # This occurs if there's no upstream repo to compare.
+            return AheadBehind()
         return AheadBehind(ahead, behind)
 
     def status(self) -> Status:

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, PropertyMock, call
+from subprocess import CalledProcessError
 from types import SimpleNamespace
 
 import pytest
@@ -91,6 +92,13 @@ def test_ahead_behind(porcelain, expected, instance):
             call(['rev-list', '@{u}..HEAD']),
             call(['rev-list', 'HEAD..@{u}']),
         ]
+
+
+def test_ahead_behind_noupstream(instance):
+    with patch('statusline.git.Git._count', side_effect=CalledProcessError(128, '')) as mock:
+        actual = instance.ahead_behind()
+        assert actual == (0, 0)
+        assert mock.call_args == call(['rev-list', '@{u}..HEAD'])
 
 
 @pytest.mark.parametrize('porcelain, expected', (


### PR DESCRIPTION
Regression occurred during the refactoring of _run_command, running rev-list against `@{u}` (upstream) results in CalledProcessError(128, '...') when there is no upstream eg. for a local branch where upstream is not set or on a detached HEAD.

Fixed by handling the error within the ahead_behind function (only when running the rev-list commnd.