### PR TITLE
Indicator for no upstream

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ Features for the future
   - [X] ideally a linting tool
   - [X] turn off requiring code reviews? (currently used to block trunk commits)
   - [ ] potential to build wheel on master?
-- [ ] indicator for not having an upstream branch set?
+- [X] indicator for not having an upstream branch set?
 - [ ] minify git branch group-name?
   - eg. feature/branch -> f/branch
   - [ ] would need to refactor out the minify to avoid a circular dependacy

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -127,7 +127,7 @@ class TestGit:
     def test_ahead_behind_noupstream(self, git):
         with patch('statusline.git.Git._count', side_effect=CalledProcessError(128, '')) as mock:
             actual = git.ahead_behind()
-            assert actual == AheadBehind()
+            assert actual is None
             assert mock.call_args == call(['rev-list', '@{u}..HEAD'])
 
     @pytest.mark.parametrize('porcelain, expected', (
@@ -148,6 +148,7 @@ class TestGit:
 
     @pytest.mark.parametrize('branch, aheadbehind, status, stashes, expected', (
         ('master', AheadBehind(0, 0), Status(0, 0, 0), 0, f'{Git.ICON}master'),
+        ('master', None, Status(0, 0, 0), 0, f'{Git.ICON}master\001\033[91m\002↯\001\033[0m\002'),
         (
             'master',
             AheadBehind(1, 0),


### PR DESCRIPTION
Added a red 'broken arrow' in the remote indicator position to indicate when no upstream branch is set.

This is done by using the fact that checking for commits ahead/behind the upstream will cause an error if no upstream exists. We've modified this to return that status so that we can use it to add this indicator.