### PR TITLE
Add support for triangle workflows

### DIFF
--- a/statusline/git.py
+++ b/statusline/git.py
@@ -139,11 +139,12 @@ class Git:
         :return: AheadBehind comparing local and remote if remote branch exists
         """
         try:
-            ahead = self._count(['rev-list', '@{u}..HEAD'])
-            behind = self._count(['rev-list', 'HEAD..@{u}'])
-            return AheadBehind(ahead, behind)
+            return AheadBehind(
+                ahead = self._count(['rev-list', '@{push}..HEAD']),
+                behind = self._count(['rev-list', 'HEAD..@{upstream}']),
+            )
         except CalledProcessError:
-            # This occurs if there's no upstream repo to compare.
+            # This occurs if there's no upstream repo to compare. (eg. a new branch)
             return None
 
     def status(self) -> Status:

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -120,15 +120,15 @@ class TestGit:
             actual = git.ahead_behind()
             assert actual == expected
             assert mock.call_args_list == [
-                call(['rev-list', '@{u}..HEAD']),
-                call(['rev-list', 'HEAD..@{u}']),
+                call(['rev-list', '@{push}..HEAD']),
+                call(['rev-list', 'HEAD..@{upstream}']),
             ]
 
     def test_ahead_behind_noupstream(self, git):
         with patch('statusline.git.Git._count', side_effect=CalledProcessError(128, '')) as mock:
             actual = git.ahead_behind()
             assert actual is None
-            assert mock.call_args == call(['rev-list', '@{u}..HEAD'])
+            assert mock.call_args == call(['rev-list', '@{push}..HEAD'])
 
     @pytest.mark.parametrize('porcelain, expected', (
         ('', Status()),


### PR DESCRIPTION
Update the ahead/behind tracker to use ..@{p} for ahead so that it's comparing against the remote that will actually be pushed to, rather than pulled from. During trianglular workflows where there may be a delay propagating changes between two remotes this will avoid counting changes that have been pushed but not propagated to @{u}. In non-triangular workflows @{p} == @{u} which will continue to work as normal.