### PR TITLE
Improve worktree support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,29 @@ Finally if the working dir is a subdirectory of the repository then the remainin
 ~/Documents/python/statusline/statusline/__pycache__ -> ~/D/p/statuslinemaster/s/__pycache__
 ```
 Using git the VCS status section takes the format `master↑1(111){1}` using the following formula:
--  - Git VCS indicator (orange banch icon)
-- master - local branch name (or HEAD for detached head states)
-- ↑1 - number of commits different between local and remote *
-  + ↑ - local commits waiting for push
-  + ↓ - remote commits waiting for pull/merge
-  + ↕ - commits in both directions - this may result in conflicts
-  + ↯ - no upstream branch is set
-- (111) - number of outstanding changes in working copy *
+- `` - Git VCS indicator (orange banch icon)
+- `master` - local branch name (or HEAD for detached head states)
+- `↑1` - number of commits different between local and remote *
+  + `↑` - local commits waiting for push
+  + `↓` - remote commits waiting for pull/merge
+  + `↕` - commits in both directions - this may result in conflicts
+  + `↯` - no upstream branch is set
+- `(111)` - number of outstanding changes in working copy *
   + first number (green) - files with staged changes *
   + second number (red) - files with unstaged changes *
   + third number (grey) - untracked files *
-- {1} - number of stash entries stored *
+- `{1}` - number of stash entries stored *
 
 \* Will not be included if there is no data to show
 
-Local stats are collected when the prompt is generated howecer remote tracking information requires remote tracking be up to date for example by using `git fetch`.
+Local stats are collected when the prompt is generated however remote tracking information requires remote tracking be up to date for example by using `git fetch`.
+
+### Worktree Support
+Worktrees are supported using three possible formats:
+```
+/home/currentuser/Documents/python/statusline/master -> ~/D/p/statusline/master
+/home/currentuser/Documents/python/statusline-master -> ~/D/p/statusline-master
+/home/currentuser/Documents/python/statusline2 -> ~/D/p/statuslinemaster
+```
+If the branch name appears at the end of the working dir it will be dropped from repo stats to avoid duplication.
+In addition, when the basename and branchname match then an additional parent directory is left at full-length.

--- a/statusline/git.py
+++ b/statusline/git.py
@@ -175,7 +175,10 @@ class Git:
         Colour coding is done with terminal escapes.
         :return: a short string which summarises repository status
         """
-        result = [self.ICON, self.branch]
+        result = [self.ICON]
+        if not self.root_dir.endswith(self.branch):
+            # No need for branch if worktree is repo-branch or repo/branch
+            result.append(self.branch)
         if ahead_behind := self.ahead_behind():
             result.append(str(ahead_behind))
         else:

--- a/statusline/status.py
+++ b/statusline/status.py
@@ -51,7 +51,11 @@ class DirectoryMinify:
         :return: the minified path with repository information inserted
         """
         common = os.path.commonpath([path, self.VCS.root_dir])
-        return self.minify_path(common) \
+        keep = 1
+        # Accomodate morktrees located in etc/repo/branch
+        if self.VCS.branch == os.path.basename(common):
+            keep += 1
+        return self.minify_path(common, keep=keep) \
             + self.VCS.short_stats() \
             + self.minify_path(path[len(common):])
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -146,9 +146,15 @@ class TestGit:
         assert actual == 1
         assert mock.call_args == call(['stash', 'list'])
 
-    @pytest.mark.parametrize('branch, aheadbehind, status, stashes, expected', (
-        ('master', AheadBehind(0, 0), Status(0, 0, 0), 0, f'{Git.ICON}master'),
+    @pytest.mark.parametrize('root, branch, aheadbehind, status, stashes, expected', (
+        # Normal clean repo
+        ('~/statusline', 'master', AheadBehind(0, 0), Status(0, 0, 0), 0, f'{Git.ICON}master'),
+        # Worktree format repo/branch
+        ('~/statusline/master', 'master', AheadBehind(0, 0), Status(0, 0, 0), 0, f'{Git.ICON}'),
+        # Worktree format repo-branch
+        ('~/statusline-master', 'master', AheadBehind(0, 0), Status(0, 0, 0), 0, f'{Git.ICON}'),
         (
+            '~/statusline',
             'feature/vcs_path_support',
             None,
             Status(0, 0, 0),
@@ -156,6 +162,7 @@ class TestGit:
             f'{Git.ICON}feature/vcs_path_support\001\033[91m\002↯\001\033[0m\002'
         ),
         (
+            '~/statusline',
             'master',
             AheadBehind(1, 0),
             Status(3, 2, 0),
@@ -163,6 +170,7 @@ class TestGit:
             f'{Git.ICON}master↑1(\001\033[32m\0023\001\033[31m\0022\001\033[0m\002)',
         ),
         (
+            '~/statusline',
             'master',
             AheadBehind(0, 1),
             Status(0, 0, 5),
@@ -170,15 +178,26 @@ class TestGit:
             f'{Git.ICON}master↓1(\001\033[90m\0025\001\033[0m\002)',
         ),
         (
+            '~/statusline',
             'DI-121-email_validation',
             AheadBehind(3, 2),
             Status(0, 0, 0),
             1,
             f'{Git.ICON}DI-121-email_validation\001\033[30;101m\002↕5\001\033[0m\002{{1}}',
         ),
+        (
+            '~/statusline/DI-121-email_validation',
+            'DI-121-email_validation',
+            AheadBehind(3, 2),
+            Status(0, 0, 0),
+            1,
+            f'{Git.ICON}\001\033[30;101m\002↕5\001\033[0m\002{{1}}',
+        ),
     ))
-    def test_short_stats(self, branch, aheadbehind, status, stashes, expected, git):
+    def test_short_stats(self, root, branch, aheadbehind, status, stashes, expected, git):
         with patch(
+            'statusline.git.Git.root_dir', new_callable=PropertyMock, return_value=root
+        ), patch(
             'statusline.git.Git.branch', new_callable=PropertyMock, return_value=branch
         ), patch(
             'statusline.git.Git.ahead_behind', return_value=aheadbehind

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -9,7 +9,8 @@ from statusline.git import Git
 @pytest.fixture()
 def instance():
     result = DirectoryMinify()
-    result.VCS = MagicMock(spec=Git)
+    result.VCS = vcs = MagicMock(spec=Git)
+    vcs.branch = 'master'
     return result
 
 
@@ -45,16 +46,32 @@ def test_minify_path_home(mock, path, expected, instance):
     assert actual == expected
 
 
-@patch('statusline.status.DirectoryMinify.minify_path', side_effect=['~/.l/s/chezmoi', '/p/i3'])
-def test__apply_vcs(mock_minify, instance):
-    instance.VCS.root_dir = '/home/kevna/.local/share/chezmoi'
-    instance.VCS.short_stats.return_value = '\uE0A0master'
-    actual = instance._apply_vcs('/home/kevna/.local/share/chezmoi/private_dot_config/i3')
-    assert actual == '~/.l/s/chezmoi\uE0A0master/p/i3'
-    mock_minify.assert_has_calls([
-        call('/home/kevna/.local/share/chezmoi'),
-        call('/private_dot_config/i3')
-    ])
+@pytest.mark.parametrize('root, stats, path, expected', (
+    (
+        '/home/kevna/.local/share/chezmoi',
+        '\uE0A0master',
+        '/home/kevna/.local/share/chezmoi/private_dot_config/i3',
+        '~/.l/s/chezmoi\uE0A0master/p/i3',
+    ),
+    (
+        '~/Documents/python/statusline/master',
+        '\uE0A0',
+        '~/Documents/python/statusline/master/statusline',
+        '~/D/p/statusline/master\uE0A0/statusline',
+    ),
+    (
+        '~/Documents/python/statusline-master',
+        '\uE0A0',
+        '~/Documents/python/statusline-master/statusline',
+        '~/D/p/statusline-master\uE0A0/statusline',
+    ),
+))
+@patch('statusline.status._hilight', side_effect=lambda x: x)
+def test__apply_vcs(mock, root, stats, path, expected, instance):
+    instance.VCS.root_dir = root
+    instance.VCS.short_stats.return_value = stats
+    actual = instance._apply_vcs(path)
+    assert actual == expected
 
 
 @patch('statusline.status.os.getcwd', return_value='/home/kevna/.local/share/chezmoi')

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 import pytest
 

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -48,9 +48,9 @@ def test_minify_path_home(mock, path, expected, instance):
 
 @pytest.mark.parametrize('root, stats, path, expected', (
     (
-        '/home/kevna/.local/share/chezmoi',
+        '~/.local/share/chezmoi',
         '\uE0A0master',
-        '/home/kevna/.local/share/chezmoi/private_dot_config/i3',
+        '~/.local/share/chezmoi/private_dot_config/i3',
         '~/.l/s/chezmoi\uE0A0master/p/i3',
     ),
     (


### PR DESCRIPTION
Gentle improvements to save space when working with worktrees, typical use case allows for `/home/user/Documents/repo/branch` since this normally results in the git root having the same name as the current branch we will drop the duplicate branch name from the stats, we also display an additional parent dir, the above example will become: `~/D/repo/branch`

Alternative possible use case, when working with a typically stashing workflow but needing a working dir might be to have `/home/user/Documents/repo2` or `/home/user/Documents/repo-branch`, these will display as `~/D/repo2branch` and `~/D/repo-branch` respectively.