### PR TITLE
fix(git): prevent errors when branch is empty

### DIFF
--- a/statusline/git.py
+++ b/statusline/git.py
@@ -114,11 +114,19 @@ class Git:
     @property
     def branch(self) -> str:
         """Property for the current branch name.
+
+        Using symbolic-ref reads HEAD directly which can point to a
+        branch even if it does not yet have any commits accossiated with it.
+        Wheras in this case rev-parse will fail since it reverse-engineers
+        the ref from the current commit.
         :return: the current local branch name
         """
-        return self._run_command(
-            ['rev-parse', '--symbolic-full-name', '--abbrev-ref', 'HEAD']
-        ).strip()
+        try:
+            return self._run_command(
+                ['symbolic-ref', '-q', '--short', 'HEAD']
+            ).strip()
+        except CalledProcessError:
+            return 'HEAD'
 
     @property
     def last_fetch(self) -> int:

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -89,7 +89,7 @@ class TestGit:
     def test_branch(self, mock, git):
         assert git.branch == 'master'
         assert mock.call_args == call(
-            ['rev-parse', '--symbolic-full-name', '--abbrev-ref', 'HEAD']
+            ['symbolic-ref', '-q', '--short', 'HEAD']
         )
 
     @patch('statusline.git.path.getmtime', return_value=1604363715.999)


### PR DESCRIPTION
avoid errors for unborn references (branches which have no commit associated)

we do this by moving from rev-parse which reverse engineers the ref from the commit to symbolic-ref which reads the refname from HEAD without touching any oid.